### PR TITLE
ENH: Adds base shellscripts

### DIFF
--- a/shellscript/commit_utils.sh
+++ b/shellscript/commit_utils.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+function blobs_in_commit() {
+    res=$(git ls-tree -r $1 | cut -d " " -f 3 | sed 's/\t.*/\n/g' | sort -u)
+    echo $res | sed 's/ /\n/g'
+}
+
+function commits_in_parents() {
+    parent1=$1
+    parent2=$2
+    commits_in_parent1=$(blobs_in_commit $parent1)
+    commits_in_parent2=$(blobs_in_commit $parent2)
+    echo $commits_in_parent1 $commits_in_parent2 | sed 's/ /\n/g' | sort -u
+}
+
+check_merge_commit() { 
+    commits_in_parents $1 $2 >  parent.tmp
+    blobs_in_commit $3 > child.tmp
+    diff -y child.tmp parent.tmp
+}
+
+get_parents(){
+    commit=$1
+    git show --format=%P $commit
+}
+
+function try_merges() {
+    for commit in $(git log --first-parent --merges --oneline | cut -d ' ' -f 1)
+    do
+        parents=$(get_parents $commit)
+        res=$(check_merge_commit $parents $commit | grep "<" | wc -w) 
+        if [ $res -ne 0 ]
+        then
+            git cat-file -p $commit
+        fi
+    done
+}
+
+get_tree() {
+    git log --pretty=%T -1 $1
+}
+
+get_parents() {
+    git log --pretty=%P -1 $1
+}

--- a/shellscript/echo.sh
+++ b/shellscript/echo.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo $@

--- a/shellscript/find_merges.sh
+++ b/shellscript/find_merges.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+. commit_utils.sh
+repo=$1
+export GIT_DIR=${repo}/.git
+git rev-list --parents --merges HEAD
+

--- a/shellscript/merge_replayer.sh
+++ b/shellscript/merge_replayer.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# include our functions
+. commit_utils.sh
+
+# We assume this is a path in the CWD
+REPO_TO_CLONE=$1
+
+# We assume there's a tool called $2.sh
+# that takes the parent commit names and performs the merge
+TOOL_FOR_REPLAY=$2
+
+# the merge list can be obtained using the find_merges.sh script
+MERGE_LIST=$3
+
+TARGET_REPO="${REPO_TO_CLONE}-${TOOL_FOR_REPLAY}"
+MERGE_COMMAND="${TOOL_FOR_REPLAY}.sh" 
+
+# clone with vanilla (this is not a contentious step)
+git clone $REPO_TO_CLONE $TARGET_REPO
+
+# we set our namespace to the new repository
+export GIT_DIR=${TARGET_REPO}/.git
+export GIT_WORK_TREE=${TARGET_REPO}
+
+cp empty-config ${TARGET_REPO}/.git/config
+
+# target logfile
+TARGET_LOGFILE=${TARGET_REPO}.merges
+
+while read line
+do
+    echo ${line}
+    branch_name=$(echo ${line} | sed "s/ /-/g")
+    all_parents=$(echo ${line} | sed "s/^.*\ //")
+    first_parent=$(echo ${line} | cut -d ' ' -f 2)
+    other_parents=$(echo ${all_parents} | sed "s/^.&\ //")
+    git checkout -q -f ${first_parent}
+    git checkout -q -b merges/${branch_name}
+    ./${MERGE_COMMAND} ${other_parents}
+    echo ${branch_name}
+
+    this_tree=$(get_tree)
+    this_parents=$(get_parents)
+    
+    echo ${this_parents}
+    echo ${all_parents}
+
+    set -x
+    if [ "${all_parents}" != "${this_parents}" ]
+    then
+        echo "Parents are not equal! ${all_parents} != ${this_parents}"
+    fi
+    set +x
+
+    echo $this_tree ${all_parents} >> $TARGET_LOGFILE
+
+done < ${MERGE_LIST}

--- a/shellscript/vanilla.sh
+++ b/shellscript/vanilla.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+git merge -q -m "commit" $@
+# git commit --allow-empty-message -m "commit"


### PR DESCRIPTION
This adds the basic shellscripts
- commit_utils.sh: A series of scripts to to get information about commits,
  trees, blobs, branches, etc. It can be sourced on other scripts
- echo.sh: A "dummy driver" that just prints the commits that are about to be merged
- find_merges.sh outputs all the parents of all merge commits (so it can be
  conveniently redirected to a file)
- merge_replayer.sh: This is the main script, it takes three arguments:
  - The target git repository to merge
  - The driver file (e.g., echo or vanilla)
  - The list of merge parents for replaying (i.e., the output of find_merges.sh)
- vanilla.sh: A driver that does a merge with all the merge parents passed
  as arguments. This uses the vanilla git version

In the context of this PR, a driver is a shellscript that wraps an implementation's merge.
The merge_replayer script will call the driver with all the parent commits as a parameter.
